### PR TITLE
V2.5 ready

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -6,7 +6,7 @@ local default_plugins = {
 
   {
     "NvChad/base46",
-    branch = "v2.0",
+    branch = "v3.0",
     build = function()
       require("base46").load_all_highlights()
     end,
@@ -14,7 +14,7 @@ local default_plugins = {
 
   {
     "NvChad/ui",
-    branch = "v2.0",
+    branch = "v3.0",
     lazy = false,
   },
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades core NvChad plugins to the latest major version.
> 
> - Change `NvChad/base46` branch to `v3.0` (was `v2.0`)
> - Change `NvChad/ui` branch to `v3.0` (was `v2.0`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17cdb55f5aedcfc6f7a6e6dec8271af67f58479a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->